### PR TITLE
Change installation path && add custom arguments

### DIFF
--- a/res/one-click/x1101.py
+++ b/res/one-click/x1101.py
@@ -83,8 +83,8 @@ if 'COLAB_GPU' in os.environ:
     ui = "/content"
     env = 'Colab'
 elif 'KAGGLE_KERNEL_RUN_TYPE' in os.environ:
-    root_path = "/kaggle/working"
-    ui = "/kaggle/working"
+    root_path = "/kaggle/sd-wui"
+    ui = "/kaggle/sd-wui"
     env = 'Kaggle'
 else:
      cprint('Error. Enviroment not detected', color="flat_red")

--- a/res/one-click/x1101.py
+++ b/res/one-click/x1101.py
@@ -290,6 +290,8 @@ if __name__ == "__main__":
     parser.add_argument("--hub_token", type=str, help="Token for HUB extension for easily downloading stuff inside WebUI, do NOT put your token here but instead link file contains the token.")
     parser.add_argument("--debug", action='store_true', help="Enable debug mode.")
     parser.add_argument("--branch", type=str, help="Switch different  for webui. Default is 'master'.")
+    parser.add_argument("--cfid", type=str, help="connector id of cloudflare tunnel.")
+    parser.add_argument("--cfdomain", type=str, help="custom domain of cf tunnel.")
     
     args = parser.parse_args()
 
@@ -378,7 +380,8 @@ if __name__ == "__main__":
     if args.zrok_token:
         subprocess.run(f"zrok enable {zrok_token}", shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         tunnel.add_tunnel(command="zrok share public http://localhost:{port}/ --headless", name="zrok", pattern=re.compile(r"[\w-]+\.share\.zrok\.io"))
-    
+    if args.cfid:
+        tunnel.add_tunnel(command=f"cloudflared service install {args.cfid}",name="cf custom",pattern=f"args.cfdomain")
     with tunnel:
         #subprocess.run("python -m http.server 1101", shell=True)
         subprocess.run(f"echo -n {start_colab} >{ui}/x1101/static/colabTimer.txt", shell=True)

--- a/res/one-click/x1101.py
+++ b/res/one-click/x1101.py
@@ -381,7 +381,6 @@ if __name__ == "__main__":
         subprocess.run(f"zrok enable {zrok_token}", shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         tunnel.add_tunnel(command="zrok share public http://localhost:{port}/ --headless", name="zrok", pattern=re.compile(r"[\w-]+\.share\.zrok\.io"))
     if args.cfid:
-        cprint(f"cl --no-autoupdate tunnel run --token {args.cfid}")
         tunnel.add_tunnel(command=f"cl --no-autoupdate tunnel run --token {args.cfid}",name="cf custom",pattern=re.compile(r'(?<=\\"hostname\\":\\")[.\w-]+(?=\\")'))
     with tunnel:
         #subprocess.run("python -m http.server 1101", shell=True)

--- a/res/one-click/x1101.py
+++ b/res/one-click/x1101.py
@@ -381,7 +381,7 @@ if __name__ == "__main__":
         subprocess.run(f"zrok enable {zrok_token}", shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         tunnel.add_tunnel(command="zrok share public http://localhost:{port}/ --headless", name="zrok", pattern=re.compile(r"[\w-]+\.share\.zrok\.io"))
     if args.cfid:
-        tunnel.add_tunnel(command=f"cloudflared service install {args.cfid}",name="cf custom",pattern=f"args.cfdomain")
+        tunnel.add_tunnel(command=f"/usr/bin/cloudflared --no-autoupdate tunnel run --token {args.cfid}",name="cf custom",pattern=re.compile(f"{args.cfdomain}"))
     with tunnel:
         #subprocess.run("python -m http.server 1101", shell=True)
         subprocess.run(f"echo -n {start_colab} >{ui}/x1101/static/colabTimer.txt", shell=True)

--- a/res/one-click/x1101.py
+++ b/res/one-click/x1101.py
@@ -382,7 +382,7 @@ if __name__ == "__main__":
         tunnel.add_tunnel(command="zrok share public http://localhost:{port}/ --headless", name="zrok", pattern=re.compile(r"[\w-]+\.share\.zrok\.io"))
     if args.cfid:
         cprint(f"cl --no-autoupdate tunnel run --token {args.cfid}")
-        tunnel.add_tunnel(command=f"cl --no-autoupdate tunnel run --token {args.cfid}",name="cf custom",pattern=re.compile(r'(?<=\\"hostname\\":\\")[\w-\.]+(?=\\")'))
+        tunnel.add_tunnel(command=f"cl --no-autoupdate tunnel run --token {args.cfid}",name="cf custom",pattern=re.compile(r'(?<=\\"hostname\\":\\")[\w-.]+(?=\\")'))
     with tunnel:
         #subprocess.run("python -m http.server 1101", shell=True)
         subprocess.run(f"echo -n {start_colab} >{ui}/x1101/static/colabTimer.txt", shell=True)

--- a/res/one-click/x1101.py
+++ b/res/one-click/x1101.py
@@ -382,7 +382,7 @@ if __name__ == "__main__":
         tunnel.add_tunnel(command="zrok share public http://localhost:{port}/ --headless", name="zrok", pattern=re.compile(r"[\w-]+\.share\.zrok\.io"))
     if args.cfid:
         cprint(f"cl --no-autoupdate tunnel run --token {args.cfid}")
-        tunnel.add_tunnel(command=f"cl --no-autoupdate tunnel run --token {args.cfid}",name="cf custom",pattern=re.compile(r'(?<=\\"hostname\\":\\")[\w-.]+(?=\\")'))
+        tunnel.add_tunnel(command=f"cl --no-autoupdate tunnel run --token {args.cfid}",name="cf custom",pattern=re.compile(r'(?<=\\"hostname\\":\\")[.\w-]+(?=\\")'))
     with tunnel:
         #subprocess.run("python -m http.server 1101", shell=True)
         subprocess.run(f"echo -n {start_colab} >{ui}/x1101/static/colabTimer.txt", shell=True)

--- a/res/one-click/x1101.py
+++ b/res/one-click/x1101.py
@@ -292,6 +292,7 @@ if __name__ == "__main__":
     parser.add_argument("--branch", type=str, help="Switch different  for webui. Default is 'master'.")
     parser.add_argument("--cfid", type=str, help="connector id of cloudflare tunnel.")
     parser.add_argument("--cfdomain", type=str, help="custom domain of cf tunnel.")
+    parser.add_argument("--pswd", type=str, help="password.")
     
     args = parser.parse_args()
 
@@ -390,6 +391,6 @@ if __name__ == "__main__":
         lol = f"sed -i -e \"s/\\[\\\"sd_model_checkpoint\\\"\\]/\\[\\\"sd_model_checkpoint\\\",\\\"sd_vae\\\",\\\"CLIP_stop_at_last_layers\\\"\\]/g\" {ui}/x1101/modules/shared_options.py"
         subprocess.run(lol, shell=True)
         if args.debug:
-            subprocess.run(f"cd {ui}/x1101 && python launch.py --port=1101 {ngrok} --api --encrypt-pass=x1101 --precision full --no-half --use-cpu SD GFPGAN BSRGAN ESRGAN SCUNet CodeFormer --all --skip-torch-cuda-test --theme dark --enable-insecure-extension-access --disable-console-progressbars --disable-safe-unpickle --no-download-sd-model", shell=True)
+            subprocess.run(f"cd {ui}/x1101 && python launch.py --port=1101 {ngrok} --api --encrypt-pass={args.pswd} --precision full --no-half --use-cpu SD GFPGAN BSRGAN ESRGAN SCUNet CodeFormer --all --skip-torch-cuda-test --theme dark --enable-insecure-extension-access --disable-console-progressbars --disable-safe-unpickle --no-download-sd-model", shell=True)
         else:
-            subprocess.run(f"cd {ui}/x1101 && python launch.py --port=1101 {ngrok} --api --encrypt-pass=x1101 --xformers --theme dark --enable-insecure-extension-access --disable-console-progressbars --disable-safe-unpickle --no-half-vae --no-download-sd-model", shell=True)
+            subprocess.run(f"cd {ui}/x1101 && python launch.py --port=1101 {ngrok} --api --encrypt-pass={args.pswd} --xformers --theme dark --enable-insecure-extension-access --disable-console-progressbars --disable-safe-unpickle --no-half-vae --no-download-sd-model", shell=True)

--- a/res/one-click/x1101.py
+++ b/res/one-click/x1101.py
@@ -382,7 +382,6 @@ if __name__ == "__main__":
         tunnel.add_tunnel(command="zrok share public http://localhost:{port}/ --headless", name="zrok", pattern=re.compile(r"[\w-]+\.share\.zrok\.io"))
     if args.cfid:
         cprint(f"cl --no-autoupdate tunnel run --token {args.cfid}")
-        cprint(f"{args.cfdomain}")
         tunnel.add_tunnel(command=f"cl --no-autoupdate tunnel run --token {args.cfid}",name="cf custom",pattern=re.compile(r'(?<=\\"hostname\\":\\")[\w-\.]+(?=\\")'))
     with tunnel:
         #subprocess.run("python -m http.server 1101", shell=True)

--- a/res/one-click/x1101.py
+++ b/res/one-click/x1101.py
@@ -383,7 +383,7 @@ if __name__ == "__main__":
     if args.cfid:
         cprint(f"cl --no-autoupdate tunnel run --token {args.cfid}")
         cprint(f"{args.cfdomain}")
-        tunnel.add_tunnel(command=f"cl --no-autoupdate tunnel run --token {args.cfid}",name="cf custom",pattern=re.compile(r"(?<=\\"hostname\\":\\")[\w-\.]+(?=\\")"))
+        tunnel.add_tunnel(command=f"cl --no-autoupdate tunnel run --token {args.cfid}",name="cf custom",pattern=re.compile(r'(?<=\\"hostname\\":\\")[\w-\.]+(?=\\")'))
     with tunnel:
         #subprocess.run("python -m http.server 1101", shell=True)
         subprocess.run(f"echo -n {start_colab} >{ui}/x1101/static/colabTimer.txt", shell=True)

--- a/res/one-click/x1101.py
+++ b/res/one-click/x1101.py
@@ -381,7 +381,9 @@ if __name__ == "__main__":
         subprocess.run(f"zrok enable {zrok_token}", shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         tunnel.add_tunnel(command="zrok share public http://localhost:{port}/ --headless", name="zrok", pattern=re.compile(r"[\w-]+\.share\.zrok\.io"))
     if args.cfid:
-        tunnel.add_tunnel(command=f"/usr/bin/cloudflared --no-autoupdate tunnel run --token {args.cfid}",name="cf custom",pattern=re.compile(f"{args.cfdomain}"))
+        cprint(f"cl --no-autoupdate tunnel run --token {args.cfid}")
+        cprint(f"{args.cfdomain}")
+        tunnel.add_tunnel(command=f"cl --no-autoupdate tunnel run --token {args.cfid}",name="cf custom",pattern=re.compile(f"{args.cfdomain}"))
     with tunnel:
         #subprocess.run("python -m http.server 1101", shell=True)
         subprocess.run(f"echo -n {start_colab} >{ui}/x1101/static/colabTimer.txt", shell=True)

--- a/res/one-click/x1101.py
+++ b/res/one-click/x1101.py
@@ -291,7 +291,6 @@ if __name__ == "__main__":
     parser.add_argument("--debug", action='store_true', help="Enable debug mode.")
     parser.add_argument("--branch", type=str, help="Switch different  for webui. Default is 'master'.")
     parser.add_argument("--cfid", type=str, help="connector id of cloudflare tunnel.")
-    parser.add_argument("--cfdomain", type=str, help="custom domain of cf tunnel.")
     parser.add_argument("--pswd", type=str, help="password.")
     
     args = parser.parse_args()
@@ -384,7 +383,7 @@ if __name__ == "__main__":
     if args.cfid:
         cprint(f"cl --no-autoupdate tunnel run --token {args.cfid}")
         cprint(f"{args.cfdomain}")
-        tunnel.add_tunnel(command=f"cl --no-autoupdate tunnel run --token {args.cfid}",name="cf custom",pattern=re.compile(f"{args.cfdomain}"))
+        tunnel.add_tunnel(command=f"cl --no-autoupdate tunnel run --token {args.cfid}",name="cf custom",pattern=re.compile(r"(?<=\\"hostname\\":\\")[\w-\.]+(?=\\")"))
     with tunnel:
         #subprocess.run("python -m http.server 1101", shell=True)
         subprocess.run(f"echo -n {start_colab} >{ui}/x1101/static/colabTimer.txt", shell=True)

--- a/res/pastebin_dl.py
+++ b/res/pastebin_dl.py
@@ -12,12 +12,7 @@ from colablib.colored_print import cprint, print_line
 from colablib.utils.config_utils import read_config
 from colablib.utils.git_utils import clone_repo
 
-if 'content' in os.listdir('/'):
-    root_path = "/content"
-elif 'kaggle' in os.listdir('/'):
-    root_path = "/kaggle/working"
-else:
-     cprint('Error. Enviroment not detected', color="flat_red")
+root_path = "/kaggle/working"
 
 webui_path = os.path.join(root_path, "x1101")
 

--- a/res/x1101.py
+++ b/res/x1101.py
@@ -4,14 +4,8 @@ import time
 import torch
 from colablib.colored_print import cprint, print_line
 
-if 'content' in os.listdir('/'):
-    ui = "/content"
-    env = 'Colab'
-elif 'kaggle' in os.listdir('/'):
-    ui = "/kaggle/working"
-    env = 'Kaggle'
-else:
-     cprint('Error. Enviroment not detected', color="flat_red")
+ui = "/kaggle/working"
+env = 'Kaggle'
     
 branch = "master"
 ui_path = os.path.join(ui, "x1101")

--- a/res/x1101.py
+++ b/res/x1101.py
@@ -53,13 +53,7 @@ if __name__ == "__main__":
 
     agus = []
     
-    if 'content' in os.listdir('/'):
-        agus.append(("pip install xformers==0.0.25 --no-deps", "Installing xformers..."))
-    elif 'kaggle' in os.listdir('/'):
-        #agus.append(("pip install torch==2.1.2+cu121 torchvision==0.16.2+cu121 torchaudio==2.1.2 --extra-index-url https://download.pytorch.org/whl/cu121", "Installing torch..."))
-        agus.append(("pip install xformers==0.0.26.post1", "Installing xformers..."))
-    else:
-        agus.append((""))
+    agus.append(("pip install xformers==0.0.26.post1", "Installing xformers..."))
             
     si_kontol = 0
     kntl = 0


### PR DESCRIPTION
- Change the installation path from `/kaggle/working` to `/kaggle/sd-wui` to eliminate the 20 GB limit on the'/kaggle/working` directory.
- Add `--pswd` argument, allowing custom the encryption password.
- Add `--cfid` argument, allowing using Cloudflare tunnel on a personal domain (need to configure in Cloudflare one dash board).